### PR TITLE
Historical context of Linux implementation

### DIFF
--- a/draft-welzl-iccrg-pacing.md
+++ b/draft-welzl-iccrg-pacing.md
@@ -321,7 +321,7 @@ to reduce this risk {{I-D.draft-johansson-ccwg-rfc8298bis-screamv2-03}}, {{Sammy
 
 ## Linux TCP {#linux}
 
-The following description is based on Linux kernel version 6.8.9.
+Pacing was first implemented in Linux kernel version 3.12 in 2013. The following description is based on Linux kernel version 6.8.9.
 
 There are two ways to enable pacing in Linux: 1) via a socket option, 2) by configuring the FQ queue discipline. We describe case 1.
 


### PR DESCRIPTION
For Apple and FreeBSD, the text mentions the version of availability:

_Pacing was added to Apple OS as a private API in iOS 17 and macOS 14._
_... which is a kernel loadable module available in FreeBSD 14 and higher._

For coherence, I propose that the text mentions when pacing was implemented also in Linux,
(in commit https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=afe4fd062416b158a8a8538b23adc1930a9b88dc
that was released in 3.12. Of course the specific commit is not very relevant in this context/RFC, but the release and the year is interesting to know - pacing support has been there for a long time.
